### PR TITLE
Add tuple support at filter

### DIFF
--- a/python_streams/streams.py
+++ b/python_streams/streams.py
@@ -8,11 +8,12 @@ T = TypeVar('T')
 V = TypeVar('V')
 
 
-def expand(func: Callable[[T], V]):
-    def expanded_func(item: T) -> V:
+def expand(func: Union[Callable[[T], V], Callable[..., V]]):
+    def expanded_func(item: ...) -> V:
         return func(*item)
 
-    return expanded_func if not isinstance(func, BuiltinFunctionType) and len(signature(func).parameters) > 1 else func
+    return (expanded_func if not isinstance(func, BuiltinFunctionType) and len(signature(func).parameters) > 1
+            else func)
 
 
 class Stream(Generic[T], Iterable):

--- a/python_streams/streams.py
+++ b/python_streams/streams.py
@@ -23,16 +23,17 @@ class Stream(Generic[T], Iterable):
     def __iter__(self) -> Iterator[T]:
         yield from self.items
 
-    def map(self, func: Callable[[T], V]) -> 'Stream[V]':
+    def map(self, func: Union[Callable[[T], V], Callable[..., V]]) -> 'Stream[V]':
         return Stream(map(expand(func), self.items))
 
-    def map_if(self, condition: Callable[[T], bool], func: Callable[[T], V]) -> 'Stream[Union[T, V]]':
+    def map_if(self, condition: Union[Callable[[T], bool], Callable[..., bool]],
+               func: Union[Callable[[T], V], Callable[..., V]]) -> 'Stream[Union[T, V]]':
         return Stream(map(lambda x: expand(func)(x) if condition(x) else x, self.items))
 
-    def filter(self, func: Callable[[T], bool]) -> 'Stream[T]':
+    def filter(self, func: Union[Callable[[T], bool], Callable[..., bool]]) -> 'Stream[T]':
         return Stream(filter(expand(func), self.items))
 
-    def for_each(self, func: Callable[[T], Any]):
+    def for_each(self, func: Union[Callable[[T], V], Callable[..., V]]):
         for x in self.items:
             expand(func)(x)
 

--- a/python_streams/streams.py
+++ b/python_streams/streams.py
@@ -6,11 +6,11 @@ T = TypeVar('T')
 V = TypeVar('V')
 
 
-def w(func):
-    def lambda_func(item):
+def expand(func: Callable[[T], V]):
+    def expanded_function(item: T) -> V:
         return func(*item) if type(item) is tuple else func(item)
 
-    return lambda_func
+    return expanded_function
 
 
 class Stream(Generic[T], Iterable):
@@ -21,17 +21,17 @@ class Stream(Generic[T], Iterable):
         yield from self.items
 
     def map(self, func: Callable[[T], V]) -> 'Stream[V]':
-        return Stream(map(w(func), self.items))
+        return Stream(map(expand(func), self.items))
 
     def map_if(self, condition: Callable[[T], bool], func: Callable[[T], V]) -> 'Stream[Union[T, V]]':
-        return Stream(map(lambda x: w(func)(x) if condition(x) else x, self.items))
+        return Stream(map(lambda x: expand(func)(x) if condition(x) else x, self.items))
 
     def filter(self, func: Callable[[T], bool]) -> 'Stream[T]':
-        return Stream(filter(w(func), self.items))
+        return Stream(filter(expand(func), self.items))
 
     def for_each(self, func: Callable[[T], Any]):
         for x in self.items:
-            w(func)(x)
+            expand(func)(x)
 
     def zip(self, other: Iterable[V]) -> 'Stream[Tuple[T, V]]':
         return Stream(zip(self.items, other))

--- a/python_streams/streams.py
+++ b/python_streams/streams.py
@@ -8,7 +8,8 @@ V = TypeVar('V')
 
 def w(func):
     def lambda_func(item):
-        return func(*item) if type(item) is Tuple else func(item)
+        return func(*item) if type(item) is tuple else func(item)
+
     return lambda_func
 
 

--- a/python_streams/streams.py
+++ b/python_streams/streams.py
@@ -20,17 +20,17 @@ class Stream(Generic[T], Iterable):
         yield from self.items
 
     def map(self, func: Callable[[T], V]) -> 'Stream[V]':
-        return Stream(map(func, self.items))
+        return Stream(map(w(func), self.items))
 
     def map_if(self, condition: Callable[[T], bool], func: Callable[[T], V]) -> 'Stream[Union[T, V]]':
-        return Stream(map(lambda x: func(x) if condition(x) else x, self.items))
+        return Stream(map(lambda x: w(func)(x) if condition(x) else x, self.items))
 
     def filter(self, func: Callable[[T], bool]) -> 'Stream[T]':
         return Stream(filter(w(func), self.items))
 
     def for_each(self, func: Callable[[T], Any]):
         for x in self.items:
-            func(x)
+            w(func)(x)
 
     def zip(self, other: Iterable[V]) -> 'Stream[Tuple[T, V]]':
         return Stream(zip(self.items, other))

--- a/python_streams/streams.py
+++ b/python_streams/streams.py
@@ -8,11 +8,7 @@ V = TypeVar('V')
 
 def w(func):
     def lambda_func(item):
-        if type(item) is Tuple:
-            return func(*item)
-        else:
-            return func(item)
-
+        return func(*item) if type(item) is Tuple else func(item)
     return lambda_func
 
 

--- a/python_streams/streams.py
+++ b/python_streams/streams.py
@@ -1,5 +1,7 @@
 from functools import lru_cache
+from inspect import signature
 from itertools import islice, chain
+from types import BuiltinFunctionType
 from typing import Iterable, Iterator, TypeVar, Callable, Tuple, Optional, Generic, List, Any, Union
 
 T = TypeVar('T')
@@ -7,10 +9,10 @@ V = TypeVar('V')
 
 
 def expand(func: Callable[[T], V]):
-    def expanded_function(item: T) -> V:
-        return func(*item) if type(item) is tuple else func(item)
+    def expanded_func(item: T) -> V:
+        return func(*item)
 
-    return expanded_function
+    return expanded_func if not isinstance(func, BuiltinFunctionType) and len(signature(func).parameters) > 1 else func
 
 
 class Stream(Generic[T], Iterable):

--- a/python_streams/streams.py
+++ b/python_streams/streams.py
@@ -6,6 +6,16 @@ T = TypeVar('T')
 V = TypeVar('V')
 
 
+def w(func):
+    def lambda_func(item):
+        if type(item) is Tuple:
+            return func(*item)
+        else:
+            return func(item)
+
+    return lambda_func
+
+
 class Stream(Generic[T], Iterable):
     def __init__(self, items: Iterable[T] = ()):
         self.items = iter(items)
@@ -20,7 +30,7 @@ class Stream(Generic[T], Iterable):
         return Stream(map(lambda x: func(x) if condition(x) else x, self.items))
 
     def filter(self, func: Callable[[T], bool]) -> 'Stream[T]':
-        return Stream(filter(func, self.items))
+        return Stream(filter(w(func), self.items))
 
     def for_each(self, func: Callable[[T], Any]):
         for x in self.items:

--- a/tests/unit/streams_test.py
+++ b/tests/unit/streams_test.py
@@ -90,3 +90,9 @@ def test_map_when_items_are_tuples():
     assert (Stream([('a', 1), ('b', 5), ('c', 3)])
             .map(lambda k, v: (k, v * 2))
             .to_list()) == [('a', 2), ('b', 10), ('c', 6)]
+
+
+def test_filter_when_items_are_tuples():
+    assert (Stream([('a', 1), ('b', 5), ('c', 3)])
+            .filter(lambda k, v: v > 3)
+            .to_list()) == [('b', 5)]

--- a/tests/unit/streams_test.py
+++ b/tests/unit/streams_test.py
@@ -40,7 +40,6 @@ accum = 0
 
 
 def test_for_each():
-
     def _side_effect(inc: int):
         global accum
         accum += inc
@@ -85,3 +84,9 @@ def test_append():
 
 def test_extend():
     assert Stream([1, 2]).extend(3).to_list() == [1, 2, 3]
+
+
+def test_map_when_items_are_tuples():
+    assert (Stream([('a', 1), ('b', 5), ('c', 3)])
+            .map(lambda k, v: (k, v * 2))
+            .to_list()) == [('a', 2), ('b', 10), ('c', 6)]


### PR DESCRIPTION
### What
Add tuple support so we can do:
```
Stream([1,2,3]).zip(['a','b','c']).filter(lambda k,v: k,v*2)
```

### Issue
Performance drop from
```
# Calculating with python-streams...
# python-streams: 6.807768106460571 seconds
# Calculating with pyfunctional...
# python-streams: 33.93324089050293 seconds
# Calculating with builtin iterators...
# python-streams: 5.716724157333374 seconds
```
to
```
**Starting Benchmark for num_primes=10000**
Calculating with python-streams...
python-streams: 14.653203964233398 seconds
Calculating with pyfunctional...
python-streams: 33.49257302284241 seconds
Calculating with builtin iterators...
python-streams: 5.7439117431640625 seconds
```

EDIT: Thanks to @biellls , now back to normal
```
**Starting Benchmark for num_primes=10000**
Calculating with python-streams...
python-streams: 7.154503107070923 seconds
Calculating with pyfunctional...
python-streams: 34.81189513206482 seconds
Calculating with builtin iterators...
python-streams: 6.267945766448975 seconds
```
